### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,13 +17,13 @@ Optimized code requires the ``fat`` module at runtime if at least one
 function was specialized.
 
 * `fatoptimizer documentation
-  <https://fatoptimizer.readthedocs.org/en/latest/>`_
+  <https://fatoptimizer.readthedocs.io/en/latest/>`_
 * `fatoptimizer project at GitHub
   <https://github.com/haypo/fatoptimizer>`_ (code, bug tracker)
 * `fatoptimizer project at the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/fatoptimizer>`_ (download releases)
-* `fat module <https://fatoptimizer.readthedocs.org/en/latest/fat.html>`_
+* `fat module <https://fatoptimizer.readthedocs.io/en/latest/fat.html>`_
 * `FAT Python
-  <https://faster-cpython.readthedocs.org/fat_python.html#fat-python>`_
+  <https://faster-cpython.readthedocs.io/fat_python.html#fat-python>`_
 * `fatoptimizer tests running on the Travis-CI
   <https://travis-ci.org/haypo/fatoptimizer>`_

--- a/doc/gsoc.rst
+++ b/doc/gsoc.rst
@@ -25,7 +25,7 @@ FAT Python
 
 FAT Python is a new static optimizer for Python 3.6, it specializes functions
 and use guards to decide if specialized code can be called or not. See `FAT
-Python homepage <http://faster-cpython.readthedocs.org/fat_python.html>`_ and
+Python homepage <https://faster-cpython.readthedocs.io/fat_python.html>`_ and
 the `slides of my talk at FOSDEM 2016
 <https://github.com/haypo/conf/raw/master/2016-FOSDEM/fat_python.pdf>`_ for
 more information.
@@ -97,13 +97,13 @@ Milestone 0 to select the student
 
 fatoptimizer:
 
-* Download `fatoptimizer <http://fatoptimizer.readthedocs.org/>`_ and run tests::
+* Download `fatoptimizer <https://fatoptimizer.readthedocs.io/>`_ and run tests::
 
     git clone https://github.com/haypo/fatoptimizer
     cd fatoptimizer
     python3 test_fatoptimizer.py
 
-* Read the `fatoptimizer documentation <http://fatoptimizer.readthedocs.org/>`_
+* Read the `fatoptimizer documentation <https://fatoptimizer.readthedocs.io/>`_
 * Pick a simple task in the :ref:`fatoptimizer TODO list <todo>` and send a
   pull request
 * MANDATORY: Submit a final PDF proposal: see
@@ -112,7 +112,7 @@ fatoptimizer:
 Optional:
 
 * Download and compile FAT Python:
-  https://faster-cpython.readthedocs.org/fat_python.html#getting-started
+  https://faster-cpython.readthedocs.io/fat_python.html#getting-started
 * Run Python test suite of FAT Python
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,13 +21,13 @@ function is specialized.
 Links:
 
 * `fatoptimizer documentation
-  <https://fatoptimizer.readthedocs.org/en/latest/>`_ (this documentation)
+  <https://fatoptimizer.readthedocs.io/en/latest/>`_ (this documentation)
 * `fatoptimizer project at GitHub
   <https://github.com/haypo/fatoptimizer>`_ (code, bug tracker)
 * `fatoptimizer project at the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/fatoptimizer>`_ (download releases)
 * `FAT Python
-  <https://faster-cpython.readthedocs.org/fat_python.html>`_
+  <https://faster-cpython.readthedocs.io/fat_python.html>`_
 * `fatoptimizer tests running on the Travis-CI
   <https://travis-ci.org/haypo/fatoptimizer>`_
 

--- a/doc/optimizations.rst
+++ b/doc/optimizations.rst
@@ -512,7 +512,7 @@ Comparison with the peephole optimizer
 ======================================
 
 The `CPython peephole optimizer
-<https://faster-cpython.readthedocs.org/bytecode.html#cpython-peephole-optimizer>`_
+<https://faster-cpython.readthedocs.io/bytecode.html#cpython-peephole-optimizer>`_
 only implements a few optimizations: :ref:`constant folding <const-fold>`,
 :ref:`dead code elimination <dead-code>` and optimizations of jumps.
 fatoptimizer implements more :ref:`optimizations <optim>`.

--- a/doc/semantics.rst
+++ b/doc/semantics.rst
@@ -25,7 +25,7 @@ As written above, it's really hard to mimic exactly CPython behaviour. For
 example, in CPython, it's technically possible to modify local variables of a
 function from anywhere, a function can modify its caller, or a thread B can
 modify a thread A (just for fun). See `Everything in Python is mutable
-<https://faster-cpython.readthedocs.org/mutable.html>`_ for more information.
+<https://faster-cpython.readthedocs.io/mutable.html>`_ for more information.
 It's also hard to support all introspections features like ``locals()``
 (``vars()``, ``dir()``), ``globals()`` and
 ``sys._getframe()``.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def main():
         'license': 'MIT license',
         'description': DESCRIPTION,
         'long_description': long_description,
-        'url': 'https://fatoptimizer.readthedocs.org/en/latest/',
+        'url': 'https://fatoptimizer.readthedocs.io/en/latest/',
         'author': 'Victor Stinner',
         'author_email': 'victor.stinner@gmail.com',
         'classifiers': CLASSIFIERS,


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.